### PR TITLE
refactoring and style fixes

### DIFF
--- a/data/Debian.yaml
+++ b/data/Debian.yaml
@@ -1,0 +1,2 @@
+---
+rspamd::manage_package_repo: true

--- a/data/FreeBSD.yaml
+++ b/data/FreeBSD.yaml
@@ -1,0 +1,2 @@
+---
+rspamd::config_path: '/usr/local/etc/rspamd'

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,0 +1,8 @@
+---
+rspamd::config_path: '/etc/rspamd'
+rspamd::manage_package_repo: false
+rspamd::package_manage: true
+rspamd::package_name: 'rspamd'
+rspamd::purge_unmanaged: true
+rspamd::repo_baseurl: undef
+rspamd::service_manage: true

--- a/hiera.yaml
+++ b/hiera.yaml
@@ -1,0 +1,16 @@
+---
+version: 5
+
+defaults:
+  datadir: 'data'
+  data_hash: 'yaml_data'
+
+hierarchy:
+  - name: 'Distribution Name'
+    path: '%{facts.os.name}.yaml'
+
+  - name: 'Operating System Family'
+    path: '%{facts.os.family}.yaml'
+
+  - name: 'common'
+    path: 'common.yaml'

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -168,4 +168,3 @@ define rspamd::config (
     notify   => Service['rspamd'],
   }
 }
-

--- a/manifests/configuration.pp
+++ b/manifests/configuration.pp
@@ -1,0 +1,18 @@
+# @api private 
+# This class handles configuration. Avoid modifying private classes.
+class rspamd::configuration inherits rspamd {
+  if ($rspamd::purge_unmanaged) {
+    file { 'purge unmanaged rspamd local.d files':
+      ensure  => 'directory',
+      path    => "${rspamd::config_path}/local.d",
+      recurse => true,
+      purge   => true,
+    }
+    file { 'purge unmanaged rspamd override.d files':
+      ensure  => 'directory',
+      path    => "${rspamd::config_path}/override.d",
+      recurse => true,
+      purge   => true,
+    }
+  }
+}

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,0 +1,10 @@
+# @api private 
+# This class handles packages. Avoid modifying private classes.
+class rspamd::install inherits rspamd {
+  if ($rspamd::package_manage) {
+    package { 'rspamd':
+      ensure => 'present',
+      name   => $rspamd::package_name,
+    }
+  }
+}

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -16,17 +16,15 @@
 #
 # @author Bernhard Frauendienst <puppet@nospam.obeliks.de>
 #
-class rspamd::repo (
-  $baseurl = undef,
-) {
-  case $::osfamily {
-    'Debian': {
-      class { 'rspamd::repo::apt_stable': }
-    }
-
-    default: {
-      fail("Unsupported managed repository for osfamily: ${::osfamily}, operatingsystem: ${::operatingsystem}, module ${module_name} currently only supports managing repos for osfamily Debian")
+class rspamd::repo inherits rspamd {
+  if($rspamd::manage_package_repo) {
+    case $::osfamily {
+      'Debian': {
+        class { 'rspamd::repo::apt_stable': }
+      }
+      default: {
+        fail("Unsupported managed repository for osfamily: ${::osfamily}, operatingsystem: ${::operatingsystem}, module ${module_name} currently only supports managing repos for osfamily Debian")
+      }
     }
   }
 }
-

--- a/manifests/repo/apt_stable.pp
+++ b/manifests/repo/apt_stable.pp
@@ -14,7 +14,7 @@ class rspamd::repo::apt_stable inherits rspamd::repo {
   #
   $default_baseurl = 'http://rspamd.com/apt-stable/'
 
-  $_baseurl = pick($rspamd::repo::baseurl, $default_baseurl)
+  $_baseurl = pick($rspamd::repo_baseurl, $default_baseurl)
 
   apt::pin { 'rspamd_stable':
     originator => 'rspamd.com',
@@ -33,4 +33,3 @@ class rspamd::repo::apt_stable inherits rspamd::repo {
   Apt::Source['rspamd_stable']->Package<|tag == 'rspamd'|>
   Class['Apt::Update'] -> Package<|tag == 'rspamd'|>
 }
-

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -1,0 +1,11 @@
+# @api private 
+# This class handles services. Avoid modifying private classes.
+class rspamd::service inherits rspamd {
+  if ($rspamd::service_manage) {
+    service { 'rspamd':
+      ensure    => 'running',
+      enable    => true,
+      subscribe => Class['rspamd::install'],
+    }
+  }
+}

--- a/manifests/ucl/config.pp
+++ b/manifests/ucl/config.pp
@@ -77,4 +77,3 @@ define rspamd::ucl::config (
     content => "${indent}${entry_key} = ${printed_value}${semicolon}",
   }
 }
-

--- a/manifests/ucl/file.pp
+++ b/manifests/ucl/file.pp
@@ -21,7 +21,8 @@ define rspamd::ucl::file (
 ) {
   concat { $file:
     owner => 'root',
-    group => 'root',
+    # Use '0' for compatibity with Linux ("root") and FreeBSD ("wheel")
+    group => 0,
     mode  => '0644',
     warn  => !$comment,
     order => 'alpha',
@@ -34,4 +35,3 @@ define rspamd::ucl::file (
     }
   }
 }
-

--- a/metadata.json
+++ b/metadata.json
@@ -8,18 +8,63 @@
   "project_page": "https://github.com/oxc/puppet-rspamd",
   "issues_url": "https://github.com/oxc/puppet-rspamd/issues",
   "dependencies": [
-    {"name":"puppetlabs-stdlib","version_requirement":">= 4.16.0"},
-    {"name":"puppetlabs-concat","version_requirement":">= 3.0.0"},
-    {"name":"puppetlabs-apt","version_requirement":">= 3.0.0"}
+    {"name":"puppetlabs-stdlib","version_requirement":">= 4.16.0 < 5.0.0"},
+    {"name":"puppetlabs-concat","version_requirement":">= 3.0.0 < 5.0.0"},
+    {"name":"puppetlabs-apt","version_requirement":">= 3.0.0 < 5.0.0"}
   ],
   "operatingsystem_support": [
     {
-    "operatingsystem": "Ubuntu",
-    "operatingsystemrelease": [
+      "operatingsystem": "RedHat",
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "CentOS",
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "OracleLinux",
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "Scientific",
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "Debian",
+      "operatingsystemrelease": [
+        "7",
+        "8",
+        "9"
+      ]
+    },
+    {
+      "operatingsystem": "Ubuntu",
+      "operatingsystemrelease": [
+        "14.04",
         "16.04"
       ]
+    },
+    {
+      "operatingsystem": "FreeBSD"
+    },
+  ],
+  "requirements": [
+    {
+      "name": "puppet",
+      "version_requirement": ">= 4.9.0 < 6.0.0"
     }
   ],
   "data_provider": null
 }
-


### PR DESCRIPTION
* Changes to comply with common practices
  * changes to module layout
    * split into standard classes: rspamd::install, rspamd::service, rspamd::configuration
  * changes to parameters
    * rename parameter `$packages_install` to `$package_manage`
    * add new parameter `$package_name` for greater flexibility
    * sort parameters alphabetically (whenever this is OK for puppet-lint)
* Introduce module data
* Add support for the FreeBSD operating system
* Only enable repo management on supported operating systems (Debian/Ubuntu)
* Set required puppet version to 4.9 for Hiera 5 support
* Pet puppet-lint / minor style fixes

Tested the old version of this module and the changes proposed in this PR on CentOS 7, this did not result in any configuration change (as expected). :)