### PR TITLE
Support newer version of stdlib

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -8,7 +8,7 @@
   "project_page": "https://github.com/oxc/puppet-rspamd",
   "issues_url": "https://github.com/oxc/puppet-rspamd/issues",
   "dependencies": [
-    {"name":"puppetlabs-stdlib","version_requirement":">= 4.16.0 < 6.5.0"},
+    {"name":"puppetlabs-stdlib","version_requirement":">= 4.16.0 < 7.0.0"},
     {"name":"puppetlabs-concat","version_requirement":">= 3.0.0 < 7.0.0"},
     {"name":"puppetlabs-apt","version_requirement":">= 3.0.0 < 8.0.0"}
   ],

--- a/metadata.json
+++ b/metadata.json
@@ -8,7 +8,7 @@
   "project_page": "https://github.com/oxc/puppet-rspamd",
   "issues_url": "https://github.com/oxc/puppet-rspamd/issues",
   "dependencies": [
-    {"name":"puppetlabs-stdlib","version_requirement":">= 4.16.0 < 5.0.0"},
+    {"name":"puppetlabs-stdlib","version_requirement":">= 4.16.0 < 6.5.0"},
     {"name":"puppetlabs-concat","version_requirement":">= 3.0.0 < 7.0.0"},
     {"name":"puppetlabs-apt","version_requirement":">= 3.0.0 < 8.0.0"}
   ],


### PR DESCRIPTION
We use this module under CentOS 7 and Puppet 6. Even with a newer version of stdlib the module works without problems, so the version should be adjusted in the metadata of the module.