### PR TITLE
Add parameter $package_ensure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Add parameter `$package_ensure`
+
 ## [1.2.0] - 2020-04-07
 This release solely changes documentation and metadata.
 

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,6 +1,7 @@
 ---
 rspamd::config_path: '/etc/rspamd'
 rspamd::manage_package_repo: false
+rspamd::package_ensure: 'present'
 rspamd::package_manage: true
 rspamd::package_name: 'rspamd'
 rspamd::purge_unmanaged: true

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -8,6 +8,7 @@
 # @example
 #   include rspamd
 #
+# @param package_ensure    specifies the ensure state of the rspamd package
 # @param package_manage    whether to install the rspamd package
 # @param service_manage    whether to manage the rspamd service
 # @param repo_baseurl	   use a different repo url instead of rspamd.com upstream repo
@@ -20,6 +21,7 @@
 class rspamd (
   String $config_path,
   Boolean $manage_package_repo,
+  String $package_ensure,
   Boolean $package_manage,
   String $package_name,
   Boolean $purge_unmanaged,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -3,7 +3,7 @@
 class rspamd::install inherits rspamd {
   if ($rspamd::package_manage) {
     package { 'rspamd':
-      ensure => 'present',
+      ensure => $rspamd::package_ensure,
       name   => $rspamd::package_name,
     }
   }


### PR DESCRIPTION
...which allows to install a specific version of rspamd by specying `$package_ensure='2.0.4'` or always using the newest version by specifying `$package_ensure='latest'`.