### PR TITLE
Bump version requirements for stdlib & concat

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,11 +10,11 @@
   "dependencies": [
     {
       "name": "puppetlabs-stdlib",
-      "version_requirement": ">= 4.16.0 < 7.0.0"
+      "version_requirement": ">= 4.16.0 < 9.0.0"
     },
     {
       "name": "puppetlabs-concat",
-      "version_requirement": ">= 3.0.0 < 7.0.0"
+      "version_requirement": ">= 3.0.0 < 8.0.0"
     },
     {
       "name": "puppetlabs-apt",


### PR DESCRIPTION
This module works fine with stdlib 8.X as well as concat 7.X, so bump versions allowed.