### PR TITLE
add support for UCL ".include" macro

### DIFF
--- a/manifests/ucl/config.pp
+++ b/manifests/ucl/config.pp
@@ -67,13 +67,26 @@ define rspamd::ucl::config (
   }
 
   $printed_value = rspamd::ucl::print_config_value($value, $type)
-  $semicolon = $printed_value ? {
-    /\A<</  => '',
-    default => ";\n"
+
+  # UCL macro syntax
+  $is_macro = $key ? {
+    /^\..*$/ => true,
+    default  => false
+  }
+
+  if ($is_macro) {
+    $delimiter = ' '
+    $semicolon = "\n"
+  } else {
+    $delimiter = ' = '
+    $semicolon = $printed_value ? {
+      /\A<</  => '',
+      default => ";\n"
+    }
   }
 
   concat::fragment { "rspamd ${file} UCL config ${section} 02 ${key} 02":
     target  => $file,
-    content => "${indent}${entry_key} = ${printed_value}${semicolon}",
+    content => "${indent}${entry_key}${delimiter}${printed_value}${semicolon}",
   }
 }


### PR DESCRIPTION
This PR adds support for the [UCL ".include" macro](https://rspamd.com/doc/configuration/ucl.html#macros-support).

These hiera options...

```
rspamd::config:
  classifier-bayes:
    .include(try=true,priority=1,duplicate=merge): $LOCAL_CONFDIR/local.d/section.conf
```

...will result in the following rspamd configuration:

```
.include(try=true,priority=1,duplicate=merge) "$LOCAL_CONFDIR/local.d/section.conf"
```